### PR TITLE
Support more project metadata in the Publish page

### DIFF
--- a/src/views/Publish.vue
+++ b/src/views/Publish.vue
@@ -33,7 +33,7 @@
     <div class="g1x2 mb-8">
       <div class="bl mr-6">
         <v-card variant="elevated" class="text-left" flat>
-          <v-card-item class="mb-10"><v-card-title> Author Info </v-card-title></v-card-item>
+          <v-card-item class="mb-10"><v-card-title> Author info </v-card-title></v-card-item>
           <v-card-text>
             <EditTextField
               need-tip

--- a/src/views/Publish.vue
+++ b/src/views/Publish.vue
@@ -31,7 +31,7 @@
     </div>
 
     <div class="g1x2 mb-8">
-      <div class="bl mr-6 mb-4">
+      <div class="bl mr-6">
         <v-card variant="elevated" class="text-left" flat>
           <v-card-item class="mb-10"><v-card-title> Author Info </v-card-title></v-card-item>
           <v-card-text>

--- a/src/views/Publish.vue
+++ b/src/views/Publish.vue
@@ -211,7 +211,7 @@ const configFieldRulesObject = {
     (value: string) => {
       if (value && value.trim()) {
         if (
-          /^([0-9a-zA-Z]([-\\.\\w]*[0-9a-zA-Z])*@([0-9a-zA-Z][-\\w]*[0-9a-zA-Z]\\.)+[a-zA-Z]{2,9})$/.test(
+          /[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?/.test(
             value.trim()
           )
         )

--- a/src/views/Publish.vue
+++ b/src/views/Publish.vue
@@ -218,6 +218,7 @@ const configFieldRulesObject = {
           return true;
         else return "The email format is not correct.";
       }
+      return true;
     },
   ],
 
@@ -238,6 +239,7 @@ const configFieldRulesObject = {
         else
           return "The URL format of the git repository is not correct. Please start with https:// or git://.";
       }
+      return true;
     },
   ],
 };

--- a/src/views/Publish.vue
+++ b/src/views/Publish.vue
@@ -68,7 +68,7 @@
 
       <div class="bl">
         <v-card variant="elevated" class="text-left" flat>
-          <v-card-item class="mb-10"><v-card-title> Package Info </v-card-title></v-card-item>
+          <v-card-item class="mb-10"><v-card-title> Package info </v-card-title></v-card-item>
           <v-card-text>
             <EditTextField
               need-tip

--- a/src/views/Publish.vue
+++ b/src/views/Publish.vue
@@ -30,7 +30,7 @@
       </v-expansion-panels>
     </div>
 
-    <div class="g1x2">
+    <div class="g1x2 mb-8">
       <div class="bl mr-6 mb-4">
         <v-card variant="elevated" class="text-left" flat>
           <v-card-item class="mb-10"><v-card-title> Author Info </v-card-title></v-card-item>

--- a/src/views/Publish.vue
+++ b/src/views/Publish.vue
@@ -66,7 +66,7 @@
         </v-card>
       </div>
 
-      <div class="bl mb-4">
+      <div class="bl">
         <v-card variant="elevated" class="text-left" flat>
           <v-card-item class="mb-10"><v-card-title> Package Info </v-card-title></v-card-item>
           <v-card-text>

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -98,7 +98,7 @@ const settings = computed(() => store.state.webinizerSettings);
 const registryRules = [
   (value: string) => {
     if (value && value.trim()) {
-      if (value.trim().startsWith("http://") || value.trim().startsWith("https://")) return true;
+      if (/^(https|http):\/\//.test(value.trim())) return true;
       return "Registry address must be full url, starting with 'http://' or 'https://'.";
     }
     return true;

--- a/src/webinizer.ts
+++ b/src/webinizer.ts
@@ -260,6 +260,17 @@ export interface ProjectProfile extends IJsonObject {
   version?: string;
 }
 
+export interface ProjectPerson {
+  name: string;
+  email?: string;
+  url?: string;
+}
+
+export interface ProjectRepository {
+  type: string;
+  url: string;
+}
+
 export interface ProjectBuildTargetConfig {
   builders?: Builder[];
   envs?: ProjectEnv;
@@ -284,6 +295,12 @@ export interface ProjectConfig extends IJsonObject {
   overallEnvs?: ProjectEnv;
   resolutions?: PkgResolution[];
   requiredBy?: { [k: string]: string };
+  author?: ProjectPerson;
+  keywords?: string;
+  repository?: ProjectRepository;
+  homepage?: string;
+  bugs?: string;
+  license?: string;
 }
 
 //////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This is to work with https://github.com/intel/webinizer/pull/9 to support more metadata fields in the Publish page.