### PR TITLE
Enhance the delete button display in EditTextField component

### DIFF
--- a/src/components/config/EditTextField.vue
+++ b/src/components/config/EditTextField.vue
@@ -230,4 +230,12 @@ watch(
 .text-readonly .popover {
   color: rgba(0 0 0 / 87%);
 }
+
+.delete-icon {
+  color: rgba(51, 51, 51, 0.5) !important;
+}
+
+.delete-icon:hover {
+  color: rgba(51, 51, 51, 1) !important;
+}
 </style>


### PR DESCRIPTION
Previously, the delete button in Local data files is basically invisible in default mode, and it's hard for the first-time users to find the delete button naturally.
![image](https://github.com/intel/webinizer-webclient/assets/79566269/d869079f-d0a5-4512-ac91-5c10e9b4c29c)

Enhance it a little bit to make the delete button display color in default mode more obvious as below.
![image](https://github.com/intel/webinizer-webclient/assets/79566269/703c3536-2e8f-48e8-9cd8-cac34ed7991a)



